### PR TITLE
fix output external address range

### DIFF
--- a/terraform/output.tf
+++ b/terraform/output.tf
@@ -3,7 +3,7 @@ output "vip_address" {
 }
 
 output "external_address_range" {
-  value = sakuracloud_subnet.bgp-subnet.ip_addresses[0] / lookup(var.external_subnet, terraform.workspace)
+  value = format("%s/%s", sakuracloud_subnet.bgp-subnet.ip_addresses[0], lookup(var.external_subnet, terraform.workspace))
 }
 
 output "k8s_router_ip_address" {


### PR DESCRIPTION
fix #21 

インライン展開("${hoge}"のやつ) が lint で弾かれてそうだったので format で実装