### PR TITLE
Terraform関係の小変更

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ init-terraform: show-ws
 		exit 0
 	fi
 	@cd terraform
-	@terraform init -backend-config="bucket=$$TF_STATE_BUCKET"
+	@terraform init -backend-config="bucket=$$TF_STATE_BUCKET" -migrate-state
 
 .PHONY: show-ws
 show-ws:

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -11,11 +11,12 @@ terraform {
     endpoints = {
       s3 = "https://s3.isk01.sakurastorage.jp"
     }
-    region                     = "jp-north-1"
-    key                        = "terraform.tfstate"
-    skip_requesting_account_id = true
-    skip_region_validation     = true
-    skip_s3_checksum           = true
+    region                      = "jp-north-1"
+    key                         = "terraform.tfstate"
+    skip_credentials_validation = true
+    skip_requesting_account_id  = true
+    skip_region_validation      = true
+    skip_s3_checksum            = true
   }
 }
 


### PR DESCRIPTION
- STSを用いたcredential validationを無効に
- terraform init時にmigrationを必ず行うように